### PR TITLE
Convert strings to objects in jsonSerialize() function

### DIFF
--- a/src/Rpc/Message/Request.php
+++ b/src/Rpc/Message/Request.php
@@ -71,7 +71,7 @@ class Request implements \JsonSerializable
     {
         return [
             'name' => $this->name,
-            'arguments' => $this->arguments
+            'arguments' => is_string($this->arguments) ? json_decode($this->arguments) : $this->arguments
         ];
     }
 }

--- a/src/Rpc/Message/Response.php
+++ b/src/Rpc/Message/Response.php
@@ -155,7 +155,7 @@ class Response implements \JsonSerializable
     {
         return [
             'code' => $this->code,
-            'message' => $this->value,
+            'message' => is_string($this->value) ? json_decode($this->value) : $this->value,
             'time' => $this->getTime()
         ];
     }


### PR DESCRIPTION
Convert strings to objects in jsonSerialize() function

This will solve double quotes problem which appears when using json_encode functions on JSON string
